### PR TITLE
Use ~/.config/aur as default folder

### DIFF
--- a/aur
+++ b/aur
@@ -151,9 +151,11 @@ def main():
         user = p['user']
 
     # If no directory was given, assume the packages should be downloaded to
-    # ~/aur.
+    # ~/.config/aur.
     if not p['dir']:
-        dir = '/home/%s/aur' % user
+        dir = '/home/%s/.config/aur' % user
+        if not os.path.exists(dir):
+            os.makedirs(dir)
     else:
         dir = os.path.expanduser(p['dir'])
 


### PR DESCRIPTION
In linux, `~/.config` is more a default than `~` to store app-data.

This pull request propose `~/.config/aur` as default